### PR TITLE
Global timeout respected when Request does not provide its own

### DIFF
--- a/src/main/java/rocks/bastion/core/CommonRequestAttributes.java
+++ b/src/main/java/rocks/bastion/core/CommonRequestAttributes.java
@@ -48,6 +48,7 @@ public class CommonRequestAttributes {
      * <li>Headers: Initialised to the empty collection of headers.</li>
      * <li>Query parameters: Initialised to the empty collection of query parameters.</li>
      * <li>Route parameters: Initialised to the empty collection of route parameters.</li>
+     * <li>Timeout: Falls back to globally configured timeout</li>
      * </ul>
      *
      * @param method The HTTP method to use for a request. Cannot be {@literal null}.
@@ -65,6 +66,7 @@ public class CommonRequestAttributes {
         headers = new LinkedList<>();
         queryParams = new LinkedList<>();
         routeParams = new LinkedList<>();
+        timeout = HttpRequest.USE_GLOBAL_TIMEOUT;
         setBody(body);
     }
 

--- a/src/main/java/rocks/bastion/core/HttpRequest.java
+++ b/src/main/java/rocks/bastion/core/HttpRequest.java
@@ -100,7 +100,7 @@ public interface HttpRequest {
      * Tests exceeding these timeouts will throw an {@link AssertionError} and be marked as failed.
      * A value of {@literal 0} indicates no timeout - the test will wait indefinitely for a response.
      *
-     * If the request does not specify its own timeout, the globally configured timeout is used instead.
+     * By default, this returns the {@link HttpRequest#USE_GLOBAL_TIMEOUT} constant, which indicates that the globally configured timeout should be used.
      *
      * @return a number (in milliseconds) representing the longest a test should wait for each phase of a request
      */

--- a/src/main/java/rocks/bastion/core/HttpRequest.java
+++ b/src/main/java/rocks/bastion/core/HttpRequest.java
@@ -11,6 +11,11 @@ import java.util.Optional;
 public interface HttpRequest {
 
     /**
+     * Constant to be returned by {@link #timeout()} if the globally configured timeout should be used when performing this request.
+     */
+    long USE_GLOBAL_TIMEOUT = -1;
+
+    /**
      * Returns a descriptive name for the contents of this request object.
      *
      * @return Description of this request
@@ -95,10 +100,12 @@ public interface HttpRequest {
      * Tests exceeding these timeouts will throw an {@link AssertionError} and be marked as failed.
      * A value of {@literal 0} indicates no timeout - the test will wait indefinitely for a response.
      *
+     * If the request does not specify its own timeout, the globally configured timeout is used instead.
+     *
      * @return a number (in milliseconds) representing the longest a test should wait for each phase of a request
      */
     default long timeout() {
-        return 0;
+        return USE_GLOBAL_TIMEOUT;
     }
 
 }

--- a/src/test/java/rocks/bastion/core/TimeoutTest.java
+++ b/src/test/java/rocks/bastion/core/TimeoutTest.java
@@ -1,5 +1,6 @@
 package rocks.bastion.core;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Stopwatch;
@@ -24,6 +25,11 @@ public class TimeoutTest extends TestWithEmbeddedServer {
     public Stopwatch stopwatch = new Stopwatch() {
     };
 
+    @After
+    public void teardown() {
+        Bastion.globals().clear();
+    }
+
     @Test(timeout = 3000L)
     public void callSlowAPI_jsonRequestWithConfiguredTimeout_requestTimesOutAfterConfiguredTimeAndTestFails() {
         JsonRequest request = JsonRequest.fromString(HttpMethod.GET, "http://localhost:9876/chikuzen-ni", "");
@@ -34,14 +40,14 @@ public class TimeoutTest extends TestWithEmbeddedServer {
     @Test(timeout = 3000L)
     public void callSlowAPI_generalRequestWithConfiguredTimeout_requestTimesOutAfterConfiguredTimeAndTestFails() {
         GeneralRequest request = GeneralRequest.get("http://localhost:9876/chikuzen-ni");
-        request.setTimeout(1750L);
+        request.setTimeout(1600L);
         performRequestAndAssertTimeout(request, request.timeout());
     }
 
     @Test(timeout = 3000L)
     public void callSlowAPI_formUrlEncodedRequestWithConfiguredTimeout_requestTimesOutAfterConfiguredTimeAndTestFails() {
         FormUrlEncodedRequest request = FormUrlEncodedRequest.withMethod(HttpMethod.GET, "http://localhost:9876/chikuzen-ni");
-        request.setTimeout(2000L);
+        request.setTimeout(1700L);
         performRequestAndAssertTimeout(request, request.timeout());
     }
 
@@ -55,14 +61,14 @@ public class TimeoutTest extends TestWithEmbeddedServer {
     @Test(timeout = 3000L)
     public void callSlowAPI_generalRequestWithNoConfiguredTimeout_requestTimesOutAfterGlobalTimeoutAndTestFails() {
         GeneralRequest request = GeneralRequest.get("http://localhost:9876/chikuzen-ni");
-        Bastion.globals().timeout(1750L);
+        Bastion.globals().timeout(1600L);
         performRequestAndAssertTimeout(request, Bastion.globals().getGlobalRequestTimeout());
     }
 
     @Test(timeout = 3000L)
     public void callSlowAPI_formUrlEncodedRequestWithNoConfiguredTimeout_requestTimesOutAfterGlobalTimeoutAndTestFails() {
         FormUrlEncodedRequest request = FormUrlEncodedRequest.withMethod(HttpMethod.GET, "http://localhost:9876/chikuzen-ni");
-        Bastion.globals().timeout(2000L);
+        Bastion.globals().timeout(1700L);
         performRequestAndAssertTimeout(request, Bastion.globals().getGlobalRequestTimeout());
     }
 

--- a/src/test/java/rocks/bastion/core/TimeoutTest.java
+++ b/src/test/java/rocks/bastion/core/TimeoutTest.java
@@ -25,30 +25,51 @@ public class TimeoutTest extends TestWithEmbeddedServer {
     };
 
     @Test(timeout = 3000L)
-    public void callSlowAPI_jsonRequest_requestTimesOutAndTestFails() {
+    public void callSlowAPI_jsonRequestWithConfiguredTimeout_requestTimesOutAfterConfiguredTimeAndTestFails() {
         JsonRequest request = JsonRequest.fromString(HttpMethod.GET, "http://localhost:9876/chikuzen-ni", "");
         request.setTimeout(1500L);
-        performRequestAndAssert(request);
+        performRequestAndAssertTimeout(request, request.timeout());
     }
 
     @Test(timeout = 3000L)
-    public void callSlowAPI_generalRequest_requestTimesOutAndTestFails() {
+    public void callSlowAPI_generalRequestWithConfiguredTimeout_requestTimesOutAfterConfiguredTimeAndTestFails() {
         GeneralRequest request = GeneralRequest.get("http://localhost:9876/chikuzen-ni");
-        request.setTimeout(1500L);
-        performRequestAndAssert(request);
+        request.setTimeout(1750L);
+        performRequestAndAssertTimeout(request, request.timeout());
     }
 
     @Test(timeout = 3000L)
-    public void callSlowAPI_formUrlEncodedRequest_requestTimesOutAndTestFails() {
+    public void callSlowAPI_formUrlEncodedRequestWithConfiguredTimeout_requestTimesOutAfterConfiguredTimeAndTestFails() {
         FormUrlEncodedRequest request = FormUrlEncodedRequest.withMethod(HttpMethod.GET, "http://localhost:9876/chikuzen-ni");
-        request.setTimeout(1500L);
-        performRequestAndAssert(request);
+        request.setTimeout(2000L);
+        performRequestAndAssertTimeout(request, request.timeout());
     }
 
-    private void performRequestAndAssert(HttpRequest request) {
+    @Test(timeout = 3000L)
+    public void callSlowAPI_jsonRequestWithNoConfiguredTimeout_requestTimesOutAfterGlobalTimeoutAndTestFails() {
+        JsonRequest request = JsonRequest.fromString(HttpMethod.GET, "http://localhost:9876/chikuzen-ni", "");
+        Bastion.globals().timeout(1500L);
+        performRequestAndAssertTimeout(request, Bastion.globals().getGlobalRequestTimeout());
+    }
+
+    @Test(timeout = 3000L)
+    public void callSlowAPI_generalRequestWithNoConfiguredTimeout_requestTimesOutAfterGlobalTimeoutAndTestFails() {
+        GeneralRequest request = GeneralRequest.get("http://localhost:9876/chikuzen-ni");
+        Bastion.globals().timeout(1750L);
+        performRequestAndAssertTimeout(request, Bastion.globals().getGlobalRequestTimeout());
+    }
+
+    @Test(timeout = 3000L)
+    public void callSlowAPI_formUrlEncodedRequestWithNoConfiguredTimeout_requestTimesOutAfterGlobalTimeoutAndTestFails() {
+        FormUrlEncodedRequest request = FormUrlEncodedRequest.withMethod(HttpMethod.GET, "http://localhost:9876/chikuzen-ni");
+        Bastion.globals().timeout(2000L);
+        performRequestAndAssertTimeout(request, Bastion.globals().getGlobalRequestTimeout());
+    }
+
+    private void performRequestAndAssertTimeout(HttpRequest request, long expectedTimeout) {
         assertThatThrownBy(() -> Bastion.request("Create Sushi", request).call())
                 .isInstanceOf(AssertionError.class)
-                .hasMessage(format("Failed to receive response before timeout of [%d] ms", request.timeout()));
+                .hasMessage(format("Failed to receive response before timeout of [%d] ms", expectedTimeout));
         assertThat(stopwatch.runtime(TimeUnit.MILLISECONDS)).as("Test runtime").isGreaterThanOrEqualTo(1000L);
     }
 }


### PR DESCRIPTION
This is a fix for #54 

I implemented the fix as suggested by @KPull. I also changed the `CommonRequestAttributes` to default to the `USE_GLOBAL_TIMEOUT` constant, instead of 0, since most of the `HttpRequest` implementations override the timeout method and delegate it to this class. Looking for feedback if there's a better approach to doing this, and if there's a better place for the `USE_GLOBAL_TIMEOUT` constant.