### PR TITLE
Properly applying headers to executableHttpRequest

### DIFF
--- a/src/main/java/rocks/bastion/core/RequestExecutor.java
+++ b/src/main/java/rocks/bastion/core/RequestExecutor.java
@@ -101,27 +101,25 @@ public class RequestExecutor {
     }
 
     private void applyHeaders() {
-        headers = new LinkedList<>();
-        ArrayList<ApiHeader> combinedHeaders = new ArrayList<>(configuration.getGlobalRequestAttributes().getGlobalHeaders());
-        combinedHeaders.addAll(bastionHttpRequest.headers());
-        if (!combinedHeaders.stream().anyMatch(header -> header.getName().equalsIgnoreCase("content-type")) && bastionHttpRequest.contentType().isPresent()) {
+        headers = new LinkedList<>(configuration.getGlobalRequestAttributes().getGlobalHeaders());
+        headers.addAll(bastionHttpRequest.headers());
+        if (headers.stream().noneMatch(header -> header.getName().equalsIgnoreCase("content-type")) && bastionHttpRequest.contentType().isPresent()) {
             headers.add(new ApiHeader("Content-Type", bastionHttpRequest.contentType().get().toString()));
         }
-        combinedHeaders.stream().forEach(header -> executableHttpRequest.header(header.getName(), header.getValue()));
-        headers.addAll(combinedHeaders);
+        headers.forEach(header -> executableHttpRequest.header(header.getName(), header.getValue()));
     }
 
     private void applyQueryParameters() {
         List<ApiQueryParam> apiQueryParams = new ArrayList<>(configuration.getGlobalRequestAttributes().getGlobalQueryParams());
         apiQueryParams.addAll(bastionHttpRequest.queryParams());
-        apiQueryParams.stream().forEach(queryParam -> executableHttpRequest.queryString(queryParam.getName(), queryParam.getValue()));
+        apiQueryParams.forEach(queryParam -> executableHttpRequest.queryString(queryParam.getName(), queryParam.getValue()));
         resolvedUrl = executableHttpRequest.getUrl();
     }
 
     private void applyRouteParameters() {
         List<RouteParam> routeParams = new ArrayList<>(configuration.getGlobalRequestAttributes().getGlobalRouteParams());
         routeParams.addAll(bastionHttpRequest.routeParams());
-        routeParams.stream().forEach(routeParam -> executableHttpRequest.routeParam(routeParam.getName(), routeParam.getValue()));
+        routeParams.forEach(routeParam -> executableHttpRequest.routeParam(routeParam.getName(), routeParam.getValue()));
         resolvedUrl = executableHttpRequest.getUrl();
     }
 

--- a/src/test/java/rocks/bastion/core/printer/HttpRequestPrinterTest.java
+++ b/src/test/java/rocks/bastion/core/printer/HttpRequestPrinterTest.java
@@ -21,9 +21,9 @@ public class HttpRequestPrinterTest {
         HttpRequestPrinter printer = new HttpRequestPrinter(prepareRequest());
         assertThat(printer.getAsString()).isEqualTo("POST /oisaje?query1=value2 HTTP/1.1\r\n" +
                 "Host: test.test\r\n" +
-                "Content-Type: application/json; charset=UTF-8\r\n" +
                 "Header1: value1\r\n" +
                 "Authorization: token\r\n" +
+                "Content-Type: application/json; charset=UTF-8\r\n" +
                 "\r\n" +
                 "{\n" +
                 "\t\"tkoast\":\"raskpor\",\n" +


### PR DESCRIPTION
There was a small bug with the way that headers are being applied to the `executableHttpRequest` which resulted in the `Content-Type` header not being added properly.

This was happening in the case where a `Content-Type` header is not manually supplied but is added via the `#contentType()` method in Bastion's `HttpRequest`.

Also made some minor simplifications to the syntax.