### PR TITLE
#73: Fixed an issue such that when binding a model fails, the response still gets printed.

### DIFF
--- a/src/main/java/rocks/bastion/core/BastionBuilderImpl.java
+++ b/src/main/java/rocks/bastion/core/BastionBuilderImpl.java
@@ -95,22 +95,23 @@ public class BastionBuilderImpl<MODEL> implements BastionBuilder<MODEL>, Respons
     @Override
     public PostExecutionBuilder<? extends MODEL> call() {
         modelResponse = null;
+        Response response = null;
         try {
             notifyListenersCallStarted(new BastionStartedEvent(request));
-            Response response = new RequestExecutor(request, getConfiguration()).execute();
+            response = new RequestExecutor(request, getConfiguration()).execute();
             model = decodeModel(response);
             modelResponse = new ModelResponse<>(response, model);
             executeAssertions(modelResponse);
             executeCallback(modelResponse);
             return this;
-        } catch (AssertionError e) {
-            notifyListenersCallFailed(new BastionFailureEvent(request, modelResponse, e));
+        } catch (AssertionError error) {
+            notifyListenersCallFailed(new BastionFailureEvent(request, response, error));
             return this;
-        } catch (Throwable t) {
-            notifyListenersCallError(new BastionErrorEvent(request, modelResponse, t));
+        } catch (Throwable throwable) {
+            notifyListenersCallError(new BastionErrorEvent(request, response, throwable));
             return this;
         } finally {
-            notifyListenersCallFinished(new BastionFinishedEvent(request, modelResponse));
+            notifyListenersCallFinished(new BastionFinishedEvent(request, response));
         }
     }
 


### PR DESCRIPTION
Related issue: #73.

I changed the `call()` method so that it keeps the raw response received which is then sent to the events, in case of failure. This will allow the Response Printer to print the response even when we don't have a `ModelResponse`.