### PR TITLE
Set project.build.sourceEncoding property to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     </licenses>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>2.8.2</jackson.version>
     </properties>
 


### PR DESCRIPTION
This is to fix the `[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!` when building via Maven.