### PR TITLE
#63, #77: Fixed FileRequestTest for Windows and test not to run on MacOS

### DIFF
--- a/src/main/java/rocks/bastion/core/FileRequest.java
+++ b/src/main/java/rocks/bastion/core/FileRequest.java
@@ -271,7 +271,8 @@ public class FileRequest implements HttpRequest {
 
     private void guessResourceMimeType(String resource) {
         try {
-            String mimeType = Files.probeContentType(Paths.get(resource));
+            String fileNameOnly = getFileNameOnly(resource);
+            String mimeType = Files.probeContentType(Paths.get(fileNameOnly));
             if (mimeType != null) {
                 generalRequest.setContentType(ContentType.create(mimeType));
             } else {
@@ -280,5 +281,11 @@ public class FileRequest implements HttpRequest {
         } catch (IOException e) {
             LOG.warning(format("Could not determine %s MIME type. Creating request with text/plain MIME type. Use setContentType() to change MIME type.", resource));
         }
+    }
+
+    private String getFileNameOnly(String resource) {
+        int lastPathSeperatorCharIndex = Math.max(resource.lastIndexOf(":"), resource.lastIndexOf("/"));
+        // If the index is -1 (because there aren't any colons or slashes), the substring will start from index 0
+        return resource.substring(lastPathSeperatorCharIndex + 1);
     }
 }

--- a/src/test/java/rocks/bastion/core/FileRequestTest.java
+++ b/src/test/java/rocks/bastion/core/FileRequestTest.java
@@ -117,7 +117,7 @@ public class FileRequestTest extends TestWithEmbeddedServer {
     @Test
     public void contentType_jsonFileType_contentTypeShouldBeJson() throws Exception {
         // See https://github.com/bastion-dev/Bastion/issues/63 and https://github.com/bastion-dev/Bastion/issues/77
-        assumeTrue("Underlying OS is Linux", SystemUtils.IS_OS_LINUX);
+        assumeTrue("Underlying OS is Linux or Windows", SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_WINDOWS);
         FileRequest request = FileRequest.post("http://localhost:9876/sushi", "classpath:/json/create_sushi_request.json");
         assertThat(request.contentType().get().getMimeType()).describedAs("Request content-type").isEqualTo("application/json");
     }

--- a/src/test/java/rocks/bastion/core/FileRequestTest.java
+++ b/src/test/java/rocks/bastion/core/FileRequestTest.java
@@ -1,5 +1,6 @@
 package rocks.bastion.core;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 import rocks.bastion.Bastion;
 import rocks.bastion.core.json.JsonResponseAssertions;
@@ -7,6 +8,7 @@ import rocks.bastion.support.embedded.Sushi;
 import rocks.bastion.support.embedded.TestWithEmbeddedServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 public class FileRequestTest extends TestWithEmbeddedServer {
 
@@ -114,6 +116,8 @@ public class FileRequestTest extends TestWithEmbeddedServer {
 
     @Test
     public void contentType_jsonFileType_contentTypeShouldBeJson() throws Exception {
+        // See https://github.com/bastion-dev/Bastion/issues/63 and https://github.com/bastion-dev/Bastion/issues/77
+        assumeTrue("Underlying OS is Linux", SystemUtils.IS_OS_LINUX);
         FileRequest request = FileRequest.post("http://localhost:9876/sushi", "classpath:/json/create_sushi_request.json");
         assertThat(request.contentType().get().getMimeType()).describedAs("Request content-type").isEqualTo("application/json");
     }


### PR DESCRIPTION
Related issues: #63, #77.

Because of some known issues on non-Linux machines, when it comes to guessing a file's MIME-type, the test for that particular functionality has been changed to run only on Linux machines.