### PR TITLE
Response Views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>rocks.bastion</groupId>
     <artifactId>bastion</artifactId>
-    <version>0.5.2-BETA</version>
+    <version>0.6-SNAPSHOT</version>
 
     <name>Bastion</name>
     <description>A Java library for testing HTTP API endpoints.</description>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -105,6 +105,7 @@ will fail if Bastion is unable to bind the received response to a model or the a
 <6> `getResponse()`: After the `call()` method is executed, you can get the HTTP response object received using the `getResponse()` method. The returned
 response object will contain the bound model obtained from the response data.
 <6> `getModel()`: After the `call()` method is executed, you can get the bound model obtained from the response data.
+<6> `getView()`: After the `call()` method is executed, you can get a specified Java object which represents the response data.
 
 Requests
 --------
@@ -213,7 +214,7 @@ WARNING: A known issue currently exists on MacOS-based systems: a JDK bug preven
 .Send a POST request using a file
 [source,java]
 -----
-Example goes here
+[ex:file-request-post]
 -----
 
 [[json-request]]
@@ -552,7 +553,8 @@ The `execute()` method takes the following parameters, which Bastion will provid
 
 * `statusCode`: The HTTP status code of the response.
 * `response` (type: `ModelResponse`): The response object which represents the received response. This object will also contain
-the object that Bastion has <<model-binding,bound>> from the response.
+the object that Bastion has <<model-binding,bound>> from the response. You can also obtain an alternate view of the response (which is not
+necessarily the model) using `getView()`.
 * `model`: The object that Bastion has <<model-binding,bound>> from the response. This is provided for convenience so that you don't need to
 use `response.getModel()` every time.
 
@@ -591,7 +593,8 @@ The process for extracting a Java object from the HTTP response data is called *
 after calling `Bastion.request()`. `bind()` takes a Java class type which you'd like to extract.
 
 For example, if the received data is a JSON-formatted string, you can extract a Java object representation of the JSON data by supplying the
-Java type which corresponds to whatever JSON you're expecting.
+Java type which corresponds to whatever JSON you're expecting. You can also get the JSON AST object bound by Jackson, by binding to `JsonNode`
+directly.
 
 .Bound model in assertions
 
@@ -613,14 +616,16 @@ Executing and Getting Data
 --------------------------
 
 Once you have configured a request and an assertions object for Bastion to execute, you can start the test using the `call()` method. Bastion
-will execute the request supplied in `request()`, bind the response to a model of the type specified in `bind()` and finally assert that the assertions
-given in `withAssertions()` hold true.
+will execute the request supplied in `request()`, bind the response to a applicable views (including a model of the type specified in `bind()`)
+and finally assert that the assertions given in `withAssertions()` hold true.
 
 Once executed, you can retrieve the response data as follows:
 
 * `getResponse()`: Returns a complete HTTP `Response` object containing all HTTP headers and the content body. It will also contain the
 model object which was bound by Bastion.
 * `getModel()`: Returns the model object which was bound by Bastion. This is a shortcut method for `getResponse().getModel()`.
+* `getView(...)`: Returns an alternative view object which was bound by Bastion. A view is a Java object which represents the response data
+which was decoded by Bastion. The model returned by `getModel()` is in fact one of the views of the response.
 
 .Getting the entire HTTP response object
 
@@ -634,6 +639,13 @@ model object which was bound by Bastion.
 [source,java]
 -----
 [ex:get-model]
+-----
+
+.Getting the JSON AST representation from the response
+
+[source,java]
+-----
+[ex:get-view]
 -----
 
 Global Configuration

--- a/src/main/java/rocks/bastion/core/DefaultBastionFactory.java
+++ b/src/main/java/rocks/bastion/core/DefaultBastionFactory.java
@@ -2,10 +2,10 @@ package rocks.bastion.core;
 
 import rocks.bastion.core.configuration.Configuration;
 import rocks.bastion.core.event.*;
-import rocks.bastion.core.model.JsonResponseDecoder;
-import rocks.bastion.core.model.ResponseDecoder;
-import rocks.bastion.core.model.ResponseDecodersRegistrar;
-import rocks.bastion.core.model.StringResponseDecoder;
+import rocks.bastion.core.view.JsonResponseDecoder;
+import rocks.bastion.core.view.ResponseDecoder;
+import rocks.bastion.core.view.ResponseDecodersRegistrar;
+import rocks.bastion.core.view.StringResponseDecoder;
 
 /**
  * The default implementation of a {@link BastionFactory} which registers a basic set of {@link ResponseDecoder model converters}. Also registers

--- a/src/main/java/rocks/bastion/core/ModelResponse.java
+++ b/src/main/java/rocks/bastion/core/ModelResponse.java
@@ -1,25 +1,29 @@
 package rocks.bastion.core;
 
 import org.apache.http.entity.ContentType;
+import rocks.bastion.core.view.Bindings;
 
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Represents an HTTP response which also has a response model object. The response model is bound from the content/body
- * of the HTTP response.
+ * Represents an HTTP response which also has a response model object and a number of views. The views are bound from the
+ * content/body of the HTTP response.
  *
  * @param <MODEL> The model object type which was bound for this HTTP response.
  */
 public class ModelResponse<MODEL> implements Response {
 
-    private Response response;
-    private MODEL model;
+    private final Response response;
+    private final MODEL model;
+    private final Bindings views;
 
-    public ModelResponse(Response response, MODEL model) {
-        this.response = response;
+    public ModelResponse(Response response, MODEL model, Bindings views) {
+        this.response = Objects.requireNonNull(response);
         this.model = model;
+        this.views = Objects.requireNonNull(views);
     }
 
     @Override
@@ -47,7 +51,25 @@ public class ModelResponse<MODEL> implements Response {
         return response.getBody();
     }
 
+    /**
+     * Returns the designated model of this response. The model is one of the response's views which was chosen using an earlier call to
+     * {@link rocks.bastion.core.builder.BindBuilder#bind(Class)}.
+     *
+     * @return The bound model of this response, if any
+     */
     public MODEL getModel() {
         return model;
+    }
+
+    /**
+     * Returns a view of this response. The view returned is of the specified type. Views are Java objects which represent the data
+     * returned in the HTTP response. For example, a JSON response would contain a JSON tree as one of the views.
+     *
+     * @param viewType The class type of view to return
+     * @param <T> The type of the returned view
+     * @return An optional container containing a view of the specified type, if any was bound
+     */
+    public <T> Optional<T> getView(Class<T> viewType) {
+        return views.getViewForType(viewType);
     }
 }

--- a/src/main/java/rocks/bastion/core/builder/PostExecutionBuilder.java
+++ b/src/main/java/rocks/bastion/core/builder/PostExecutionBuilder.java
@@ -37,7 +37,7 @@ public interface PostExecutionBuilder<MODEL> {
     ModelResponse<? extends MODEL> getResponse();
 
     /**
-     * Gets a particular view of the received model. A view is a Java object which represents the data received in the response. This allows
+     * Gets a particular view of the response. A view is a Java object which represents the data received in the response. This allows
      * users to get a different type of object other than the one provided in the {@link BindBuilder#bind(Class) bind()} method. Note that
      * the model object returned by {@link #getModel()} would be one of the views of the response.
      *

--- a/src/main/java/rocks/bastion/core/builder/PostExecutionBuilder.java
+++ b/src/main/java/rocks/bastion/core/builder/PostExecutionBuilder.java
@@ -2,6 +2,8 @@ package rocks.bastion.core.builder;
 
 import rocks.bastion.core.ModelResponse;
 
+import java.util.Optional;
+
 /**
  * Specifies the operations available on a Bastion fluent-builder after the test has been executed with {@link ExecuteRequestBuilder#call()} and
  * a response has been obtained. At this point, Bastion will have obtained a response and decoded the response body into
@@ -34,4 +36,14 @@ public interface PostExecutionBuilder<MODEL> {
      */
     ModelResponse<? extends MODEL> getResponse();
 
+    /**
+     * Gets a particular view of the received model. A view is a Java object which represents the data received in the response. This allows
+     * users to get a different type of object other than the one provided in the {@link BindBuilder#bind(Class) bind()} method. Note that
+     * the model object returned by {@link #getModel()} would be one of the views of the response.
+     *
+     * @param viewType The class of the view object you want returned from the response
+     * @param <T> The type of view returned by this method
+     * @return An optional container with the view of the received response of the specified type, if any
+     */
+    <T> Optional<T> getView(Class<T> viewType);
 }

--- a/src/main/java/rocks/bastion/core/view/Bindings.java
+++ b/src/main/java/rocks/bastion/core/view/Bindings.java
@@ -1,0 +1,51 @@
+package rocks.bastion.core.view;
+
+import org.apache.commons.lang3.ClassUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Represents a map of view bindings. Given a view type, will return the associated view with that binding.
+ */
+public final class Bindings {
+
+    public static <T> Bindings single(Class<? super T> viewType, T view) {
+        Bindings bindings = new Bindings();
+        bindings.addBinding(viewType, view);
+        return bindings;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Bindings hierarchy(Class<? super T> viewType, T view) {
+        Bindings bindings = new Bindings();
+        for (Class<?> superType : ClassUtils.hierarchy(viewType, ClassUtils.Interfaces.INCLUDE)) {
+            bindings.addBinding((Class<? super T>) superType, view);
+        }
+        return bindings;
+    }
+
+    private final Map<Class<?>, Object> bindings;
+
+    public Bindings() {
+        bindings = new HashMap<>();
+    }
+
+    public <T> void addBinding(Class<? super T> viewType, T view) {
+        Objects.requireNonNull(viewType);
+        Objects.requireNonNull(view);
+        bindings.put(viewType, view);
+    }
+
+    public void addAllBindings(Bindings bindings) {
+        Objects.requireNonNull(bindings);
+        this.bindings.putAll(bindings.bindings);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Optional<T> getViewForType(Class<T> viewType) {
+        return Optional.ofNullable((T) bindings.get(viewType));
+    }
+}

--- a/src/main/java/rocks/bastion/core/view/Bindings.java
+++ b/src/main/java/rocks/bastion/core/view/Bindings.java
@@ -18,6 +18,15 @@ public final class Bindings {
         return bindings;
     }
 
+    /**
+     * Creates a Bindings object containing the entire class hierarchy of the given view type. All extended classes and interfaces
+     * implemented by the given type will be bound to the specified view.
+     *
+     * @param viewType The class representing the type of view to bind
+     * @param view The view object to bind
+     * @param <T> The type of view to bind
+     * @return A bindings object
+     */
     @SuppressWarnings("unchecked")
     public static <T> Bindings hierarchy(Class<? super T> viewType, T view) {
         Bindings bindings = new Bindings();

--- a/src/main/java/rocks/bastion/core/view/DecodingHints.java
+++ b/src/main/java/rocks/bastion/core/view/DecodingHints.java
@@ -1,4 +1,4 @@
-package rocks.bastion.core.model;
+package rocks.bastion.core.view;
 
 import java.util.Optional;
 

--- a/src/main/java/rocks/bastion/core/view/DecodingHints.java
+++ b/src/main/java/rocks/bastion/core/view/DecodingHints.java
@@ -7,9 +7,9 @@ import java.util.Optional;
  * that was requested by the user, if any, so that a {@link ResponseDecoder} can decode the response into a specific model
  * as requested by the user.
  */
-public class DecodingHints {
+public final class DecodingHints {
 
-    private Class<?> modelType;
+    private final Class<?> modelType;
 
     public DecodingHints(Class<?> modelType) {
         this.modelType = modelType;

--- a/src/main/java/rocks/bastion/core/view/JsonResponseDecoder.java
+++ b/src/main/java/rocks/bastion/core/view/JsonResponseDecoder.java
@@ -1,4 +1,4 @@
-package rocks.bastion.core.model;
+package rocks.bastion.core.view;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.TreeNode;
@@ -8,16 +8,15 @@ import org.apache.http.entity.ContentType;
 import rocks.bastion.core.Response;
 
 import java.io.IOException;
-import java.util.Optional;
 
 /**
  * A {@link ResponseDecoder} which will interpret an HTTP response containing JSON content body. This implementation uses
  * the Jackson library's {@link ObjectMapper} to perform the decoding operation.
  * <p>
- * The decoder uses the following strategy when attempting to construct the model object for the response: first, it
- * parses the HTTP response's JSON content into an {@link JsonNode abstract syntax tree representing the given JSON}
- * (known as a JSON tree). Then, if the user has supplied a target model type, it binds the JSON tree into an instance
- * of that type. Otherwise, it immediately returns the decoded JSON tree as an object of type {@link JsonNode}.
+ * The decoder creates the following views: first, it
+ * parses the HTTP response's JSON content into a {@link JsonNode} which is abstract syntax tree representing the given JSON
+ * (known as a JSON tree). Then, if the user has supplied a target model type, it attempts to bind the JSON tree into an instance
+ * of that type (and the entire hierarchy of the given type).
  * </p>
  */
 public class JsonResponseDecoder implements ResponseDecoder {
@@ -25,20 +24,23 @@ public class JsonResponseDecoder implements ResponseDecoder {
     private static ObjectMapper jsonObjectMapper = null;
 
     @Override
-    public Optional<?> decode(Response response, DecodingHints hints) {
+    public Bindings decode(Response response, DecodingHints hints) {
         ContentType responseContentType = response.getContentType().orElse(ContentType.DEFAULT_TEXT);
         if (!supportsContentType(responseContentType)) {
-            return Optional.empty();
+            return new Bindings();
         }
-        JsonNode decodedJsonTree;
         try {
+            Bindings bindings = new Bindings();
+            JsonNode decodedJsonTree;
             decodedJsonTree = getObjectMapper().readTree(response.getBody());
+            bindings.addAllBindings(Bindings.hierarchy(JsonNode.class, decodedJsonTree));
+            bindings.addAllBindings(decodeTreeUsingHints(decodedJsonTree, hints));
+            return bindings;
         } catch (JsonProcessingException ignored) {
-            return Optional.empty();
+            return new Bindings();
         } catch (IOException exception) {
             throw new IllegalStateException("An unexpected error occurred while reading JSON data", exception);
         }
-        return decodeTreeUsingHints(decodedJsonTree, hints);
     }
 
     private static synchronized ObjectMapper getObjectMapper() {
@@ -48,14 +50,15 @@ public class JsonResponseDecoder implements ResponseDecoder {
         return jsonObjectMapper;
     }
 
-    private Optional<?> decodeTreeUsingHints(TreeNode decodedJsonTree, DecodingHints hints) {
-        return Optional.of(hints.getModelType().<Object>map(modelType -> {
+    @SuppressWarnings("unchecked")
+    private Bindings decodeTreeUsingHints(TreeNode decodedJsonTree, DecodingHints hints) {
+        return hints.getModelType().map(modelType -> {
             try {
-                return getObjectMapper().treeToValue(decodedJsonTree, modelType);
+                return Bindings.hierarchy((Class<? super Object>) modelType, getObjectMapper().treeToValue(decodedJsonTree, modelType));
             } catch (JsonProcessingException ignored) {
                 return null;
             }
-        }).orElse(decodedJsonTree));
+        }).orElse(new Bindings());
     }
 
     private boolean supportsContentType(ContentType responseContentType) {

--- a/src/main/java/rocks/bastion/core/view/ResponseDecoder.java
+++ b/src/main/java/rocks/bastion/core/view/ResponseDecoder.java
@@ -1,25 +1,23 @@
-package rocks.bastion.core.model;
+package rocks.bastion.core.view;
 
 import rocks.bastion.core.Response;
-
-import java.util.Optional;
 
 /**
  * Interprets and decodes an HTTP response into a model object. Bastion will ask {@linkplain ResponseDecoder}s to decode the
  * HTTP response if possible. A typical implementation will first look at the response's {@code Content-type} header and attempt
  * to generate some sort of object. If the decoder is unable to decode the HTTP response into a Java object
- * (because it cannot interpret the given {@code Content-type}, for example), then then it should return an {@link Optional#empty()
- * empty Optional}.
+ * (because it cannot interpret the given {@code Content-type}, for example), then then it should return an {@link Bindings
+ * empty Bindings object}.
  * <br><br>
  * Once registered with Bastion, the {@linkplain ResponseDecoder}s will form a strategy for turning an arbitrary HTTP response
- * to a usable Java object available in Bastion tests and assertions.
+ * to a number of usable Java object (so-called views) available in Bastion tests and assertions.
  */
 public interface ResponseDecoder {
 
     /**
-     * Attempts to decode the given HTTP response to a Java object. If this decoder is unable to decode the
-     * HTTP response, then it should return an {@link Optional#empty() empty Optional}. Otherwise, it should return
-     * an {@link Optional#of(Object) Optional container containing the decoded object}.
+     * Attempts to decode the given HTTP response to a number of Java objects (ie. views). If this decoder is unable to decode the
+     * HTTP response, then it should return an {@link Bindings empty Bindings object}. Otherwise, it should return
+     * {@link Bindings bindings for all possible views of the given response}.
      * <p>
      * A user might have supplied a <i>target</i> object type it wants the decoded information bound to. In this case,
      * the target model type to bind to will be given in the {@code hints} parameter, accessible using the
@@ -27,8 +25,7 @@ public interface ResponseDecoder {
      *
      * @param response The HTTP response for the converter to decode
      * @param hints    Additional hints which can be used for decoding the provided response
-     * @return An empty {@link Optional} if this converter cannot decode the HTTP response. An {@link Optional} containing
-     * the decoded object, otherwise.
+     * @return A non-{@literal null} {@link Bindings} object
      */
-    Optional<?> decode(Response response, DecodingHints hints);
+    Bindings decode(Response response, DecodingHints hints);
 }

--- a/src/main/java/rocks/bastion/core/view/ResponseDecodersRegistrar.java
+++ b/src/main/java/rocks/bastion/core/view/ResponseDecodersRegistrar.java
@@ -1,4 +1,4 @@
-package rocks.bastion.core.model;
+package rocks.bastion.core.view;
 
 /**
  * Responsible for registering {@link ResponseDecoder}s with Bastion instances.

--- a/src/main/java/rocks/bastion/core/view/StringResponseDecoder.java
+++ b/src/main/java/rocks/bastion/core/view/StringResponseDecoder.java
@@ -1,4 +1,4 @@
-package rocks.bastion.core.model;
+package rocks.bastion.core.view;
 
 import com.google.common.io.CharStreams;
 import org.apache.http.Consts;
@@ -8,7 +8,6 @@ import rocks.bastion.core.Response;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
-import java.util.Optional;
 
 /**
  * A {@link ResponseDecoder} which will take the HTTP response content-body and put it in to a {@link String}. This should be
@@ -19,12 +18,12 @@ import java.util.Optional;
 public class StringResponseDecoder implements ResponseDecoder {
 
     @Override
-    public Optional<?> decode(Response response, DecodingHints hints) {
+    public Bindings decode(Response response, DecodingHints hints) {
         try {
             Charset responseCharset = response.getContentType().map(ContentType::getCharset).orElse(Consts.ISO_8859_1);
-            return Optional.of(CharStreams.toString(new InputStreamReader(response.getBody(), responseCharset)));
+            return Bindings.hierarchy(String.class, CharStreams.toString(new InputStreamReader(response.getBody(), responseCharset)));
         } catch (IOException ignored) {
-            return Optional.empty();
+            return new Bindings();
         }
     }
 

--- a/src/main/java/rocks/bastion/core/view/ViewBinder.java
+++ b/src/main/java/rocks/bastion/core/view/ViewBinder.java
@@ -1,0 +1,32 @@
+package rocks.bastion.core.view;
+
+import rocks.bastion.core.Response;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Responsible for extracting as many different views as possible of the given response. A view binder is first constructed using a
+ * {@link rocks.bastion.core.Response response object} and a list of {@link ResponseDecoder response decoders}. The binder will execute
+ * the decoders, in order, and build a map of types to views. If any response decoder returns a mapping which already exists, the new
+ * mapping overwrites the earlier mapping.
+ */
+public final class ViewBinder {
+
+    private final Response response;
+    private final List<ResponseDecoder> decoders;
+
+    public ViewBinder(Response response, List<ResponseDecoder> decoders) {
+        this.response = Objects.requireNonNull(response);
+        this.decoders = Objects.requireNonNull(decoders);
+    }
+
+    public Bindings bind(DecodingHints hints) {
+        Bindings bindings = new Bindings();
+        for (ResponseDecoder decoder : decoders) {
+            bindings.addAllBindings(decoder.decode(response, hints));
+        }
+        return bindings;
+    }
+
+}

--- a/src/test/java/rocks/bastion/core/ResponseViewsTest.java
+++ b/src/test/java/rocks/bastion/core/ResponseViewsTest.java
@@ -1,0 +1,84 @@
+package rocks.bastion.core;
+
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.JsonSerializable;
+import org.junit.Test;
+import rocks.bastion.Bastion;
+import rocks.bastion.core.json.JsonResponseAssertions;
+import rocks.bastion.support.embedded.Sushi;
+import rocks.bastion.support.embedded.TestWithEmbeddedServer;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResponseViewsTest extends TestWithEmbeddedServer {
+
+    @Test
+    public void stringResponseView() throws Exception {
+        ModelResponse<? extends Sushi> response = Bastion.request(FileRequest.post("http://localhost:9876/sushi",
+                                                                                   "classpath:/json/create_sushi_request.json"))
+                                                         .bind(Sushi.class)
+                                                         .withAssertions(JsonResponseAssertions.fromResource(201,
+                                                                                                             "classpath:/json/create_sushi_response.json")
+                                                                                               .ignoreValuesForProperties("/id"))
+                                                         .call()
+                                                         .getResponse();
+        Optional<String> responseString = response.getView(String.class);
+        assertThat(responseString).isNotEmpty();
+    }
+
+    @Test
+    public void jsonSerializableResponseView() throws Exception {
+        ModelResponse<? extends Sushi> response = Bastion.request(FileRequest.post("http://localhost:9876/sushi",
+                                                                                   "classpath:/json/create_sushi_request.json"))
+                                                         .bind(Sushi.class)
+                                                         .call()
+                                                         .getResponse();
+        Optional<JsonSerializable.Base> node = response.getView(JsonSerializable.Base.class);
+        assertThat(node).isNotEmpty();
+    }
+
+    @Test
+    public void treeNodeResponseView() throws Exception {
+        ModelResponse<? extends Sushi> response = Bastion.request(FileRequest.post("http://localhost:9876/sushi",
+                                                                                   "classpath:/json/create_sushi_request.json"))
+                                                         .bind(Sushi.class)
+                                                         .call()
+                                                         .getResponse();
+        Optional<TreeNode> node = response.getView(TreeNode.class);
+        assertThat(node).isNotEmpty();
+    }
+
+    @Test
+    public void treeNodeResponseView_afterCall() throws Exception {
+        Optional<TreeNode> responseNode = Bastion.request(FileRequest.post("http://localhost:9876/sushi",
+                                                                           "classpath:/json/create_sushi_request.json"))
+                                                 .bind(Sushi.class)
+                                                 .call()
+                                                 .getView(TreeNode.class);
+        assertThat(responseNode).isNotNull();
+    }
+
+    @Test
+    public void jsonBoundResponseView() throws Exception {
+        ModelResponse<? extends Sushi> response = Bastion.request(FileRequest.post("http://localhost:9876/sushi",
+                                                                                   "classpath:/json/create_sushi_request.json"))
+                                                         .bind(Sushi.class)
+                                                         .call()
+                                                         .getResponse();
+        Optional<Sushi> boundModel = response.getView(Sushi.class);
+        assertThat(boundModel).isNotEmpty();
+    }
+
+    @Test
+    public void inexistantResponseView() throws Exception {
+        ModelResponse<? extends Sushi> response = Bastion.request(FileRequest.post("http://localhost:9876/sushi",
+                                                                                   "classpath:/json/create_sushi_request.json"))
+                                                         .bind(Sushi.class)
+                                                         .call()
+                                                         .getResponse();
+        Optional<Integer> boundModel = response.getView(Integer.class);
+        assertThat(boundModel).isEmpty();
+    }
+}

--- a/src/test/java/rocks/bastion/core/StatusCodeAssertionsTest.java
+++ b/src/test/java/rocks/bastion/core/StatusCodeAssertionsTest.java
@@ -1,6 +1,7 @@
 package rocks.bastion.core;
 
 import org.junit.Test;
+import rocks.bastion.core.view.Bindings;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
@@ -51,6 +52,9 @@ public class StatusCodeAssertionsTest {
     }
 
     private ModelResponse<String> getResponseWithStatusCode(int statusCode) {
-        return new ModelResponse<>(new RawResponse(statusCode, "Status Code", Collections.emptyList(), new ByteArrayInputStream(new byte[0])), "Model");
+        String data = "Model";
+        return new ModelResponse<>(new RawResponse(statusCode, "Status Code", Collections.emptyList(), new ByteArrayInputStream(new byte[0])),
+                                   data,
+                                   Bindings.single(String.class, data));
     }
 }

--- a/src/test/java/rocks/bastion/core/assertions/TestModelResponse.java
+++ b/src/test/java/rocks/bastion/core/assertions/TestModelResponse.java
@@ -3,6 +3,7 @@ package rocks.bastion.core.assertions;
 import rocks.bastion.core.ApiHeader;
 import rocks.bastion.core.ModelResponse;
 import rocks.bastion.core.RawResponse;
+import rocks.bastion.core.view.Bindings;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
@@ -32,7 +33,7 @@ class TestModelResponse {
         return new ModelResponse<>(new RawResponse(200,
                                                    "OK",
                                                    Collections.singletonList(new ApiHeader("Content-type", contentType)), new ByteArrayInputStream(jsonContent.getBytes())),
-                                                   jsonContent);
+                                   jsonContent, Bindings.single(String.class, jsonContent));
     }
 
 }

--- a/src/test/java/rocks/bastion/core/view/ViewBinderTest.java
+++ b/src/test/java/rocks/bastion/core/view/ViewBinderTest.java
@@ -1,0 +1,58 @@
+package rocks.bastion.core.view;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+import rocks.bastion.core.RawResponse;
+import rocks.bastion.core.Response;
+
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ViewBinderTest {
+
+    @Test
+    public void bind_actualTypes() throws Exception {
+        ViewBinder viewbinder = viewBinderForStrings();
+        assertThat(viewbinder.bind(new DecodingHints(String.class)).getViewForType(String.class)).hasValue("Bound string");
+        assertThat(viewbinder.bind(new DecodingHints(StringBuffer.class)).getViewForType(StringBuffer.class))
+                .hasValueSatisfying(buffer -> buffer.toString().equals("Bound string buffer"));
+    }
+
+    @Test
+    public void bind_unboundType_emptyOptional() throws Exception {
+        ViewBinder viewbinder = viewBinderForStrings();
+        assertThat(viewbinder.bind(new DecodingHints(String.class)).getViewForType(Integer.class)).isEmpty();
+    }
+
+    @Test
+    public void bind_multipleViewsForType_overrideBinding() throws Exception {
+        ViewBinder viewbinder = viewBinderForStrings();
+        assertThat(viewbinder.bind(new DecodingHints(StringBuffer.class)).getViewForType(StringBuffer.class))
+                .hasValueSatisfying(buffer -> buffer.toString().equals("Bound string buffer"));
+    }
+
+    private ViewBinder viewBinderForStrings() {
+        return new ViewBinder(new RawResponse(200, "OK", Collections.emptyList(), new ByteArrayInputStream(new byte[0])),
+                              Lists.newArrayList(new TestDecoder<>(String.class, "Bound string"),
+                                                 new TestDecoder<>(StringBuffer.class,
+                                                                   new StringBuffer("Bound string buffer"))));
+    }
+
+    private static final class TestDecoder<T> implements ResponseDecoder {
+
+        private final Class<T> bindType;
+        private final T viewObject;
+
+        private TestDecoder(Class<T> bindType, T viewObject) {
+            this.bindType = bindType;
+            this.viewObject = viewObject;
+        }
+
+        @Override
+        public Bindings decode(Response response, DecodingHints hints) {
+            return Bindings.hierarchy(bindType, viewObject);
+        }
+    }
+}

--- a/src/test/java/rocks/bastion/documentation/UserGuideTest.java
+++ b/src/test/java/rocks/bastion/documentation/UserGuideTest.java
@@ -1,5 +1,6 @@
 package rocks.bastion.documentation;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.entity.ContentType;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -12,6 +13,7 @@ import rocks.bastion.support.embedded.Sushi;
 import rocks.bastion.support.embedded.TestWithProxiedEmbeddedServer;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,6 +65,16 @@ public class UserGuideTest extends TestWithProxiedEmbeddedServer {
         ).call();
         // docs:general-request-post
     }
+
+    @Test
+    public void fileRequest_post() {
+        // docs:file-request-post
+        Bastion.request(FileRequest.post("http://sushi-shop.test/greeting", "classpath:fixture/greeting.html")
+                            .setContentType(ContentType.TEXT_HTML)
+        ).call();
+        // docs:file-request-post
+    }
+
 
     @Test
     public void jsonRequest_postFromString() {
@@ -312,6 +324,17 @@ public class UserGuideTest extends TestWithProxiedEmbeddedServer {
 
         System.out.println(sushi.getName());
         // docs:get-model
+    }
+
+    @Test
+    public void getView() {
+        // docs:get-view
+        Optional<JsonNode> json =
+                Bastion.request(JsonRequest.postFromResource("http://sushi-shop.test/sushi", "classpath:/json/create_sushi_request.json"))
+                       .bind(Sushi.class)
+                       .call()
+                       .getView(JsonNode.class);
+        // docs:get-view
     }
 
 }


### PR DESCRIPTION
Related issue: #44.

In this pull request, I added the concept of views to Bastion to reduce the problems with using `bind()`. Now, `bind()` will work better because Bastion will attempt to extract as many views of the same response as possible. All these views will be available for binding to a model.

Also, all the extracted views will be available using `getView()` after the `call()` method during a test.