### PR TITLE
Using Apache Tika to detect resource MIME type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             <version>3.4</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.16</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>4.2.5.RELEASE</version>

--- a/src/main/java/rocks/bastion/core/FileRequest.java
+++ b/src/main/java/rocks/bastion/core/FileRequest.java
@@ -1,13 +1,11 @@
 package rocks.bastion.core;
 
 import org.apache.http.entity.ContentType;
+import org.apache.tika.Tika;
 import rocks.bastion.core.resource.ResourceLoader;
 import rocks.bastion.core.resource.ResourceNotFoundException;
 import rocks.bastion.core.resource.UnreadableResourceException;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -214,7 +212,7 @@ public class FileRequest implements HttpRequest {
 
     /**
      * Sets the timeout, in milliseconds, that will cause the test to fail if no response response is received within the specified timeout.
-     *
+     * <p>
      * A value of {@literal 0} indicates no timeout; the test will wait indefinitely for a response.
      *
      * @return a number (in milliseconds) representing this requests's timeout
@@ -270,14 +268,10 @@ public class FileRequest implements HttpRequest {
     }
 
     private void guessResourceMimeType(String resource) {
-        try {
-            String mimeType = Files.probeContentType(Paths.get(resource));
-            if (mimeType != null) {
-                generalRequest.setContentType(ContentType.create(mimeType));
-            } else {
-                LOG.warning(format("Could not determine %s MIME type. Creating request with text/plain MIME type. Use setContentType() to change MIME type.", resource));
-            }
-        } catch (IOException e) {
+        String mimeType = new Tika().detect(resource);
+        if (mimeType != null) {
+            generalRequest.setContentType(ContentType.create(mimeType));
+        } else {
             LOG.warning(format("Could not determine %s MIME type. Creating request with text/plain MIME type. Use setContentType() to change MIME type.", resource));
         }
     }

--- a/src/main/java/rocks/bastion/core/FileRequest.java
+++ b/src/main/java/rocks/bastion/core/FileRequest.java
@@ -19,7 +19,7 @@ import static java.lang.String.format;
  * <p>
  * By default, this request will contain no headers (except for the content-type) and no query parameters. Use the {@link #addHeader(String, String)}
  * and {@link #addQueryParam(String, String)}} to add them. Also, initially, Bastion will attempt to guess the MIME type to send as part of the
- * "Content-type" header by looking at the given file. If no MIME type could be chosen, the request will have the "text/plain" content-type MIME
+ * "Content-type" header by looking at the given file. If no MIME type could be chosen, the request will have the "application/octet-stream" content-type MIME
  * (which is automatically added to the HTTP headers by Bastion): you can change this content-type by calling the {@link #setContentType(ContentType)}
  * method.
  */
@@ -272,7 +272,7 @@ public class FileRequest implements HttpRequest {
         if (mimeType != null) {
             generalRequest.setContentType(ContentType.create(mimeType));
         } else {
-            LOG.warning(format("Could not determine %s MIME type. Creating request with text/plain MIME type. Use setContentType() to change MIME type.", resource));
+            LOG.warning(format("Could not determine %s MIME type. Creating request with application/octet-stream MIME type. Use setContentType() to change MIME type.", resource));
         }
     }
 }

--- a/src/main/java/rocks/bastion/core/FileRequest.java
+++ b/src/main/java/rocks/bastion/core/FileRequest.java
@@ -272,7 +272,7 @@ public class FileRequest implements HttpRequest {
         if (mimeType != null) {
             generalRequest.setContentType(ContentType.create(mimeType));
         } else {
-            LOG.warning(format("Could not determine %s MIME type. Creating request with application/octet-stream MIME type. Use setContentType() to change MIME type.", resource));
+            LOG.warning(format("Could not determine %s MIME type. Use setContentType() to change MIME type.", resource));
         }
     }
 }

--- a/src/main/java/rocks/bastion/core/FileRequest.java
+++ b/src/main/java/rocks/bastion/core/FileRequest.java
@@ -10,8 +10,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import static java.lang.String.format;
-
 /**
  * An HTTP request which takes any arbitrary file/resource, using the data within as its content body. The {@linkplain FileRequest} will not perform
  * any conversions or validation on any user-supplied body content. Use the static factory methods, such as {@link #post(String, String)}
@@ -269,10 +267,12 @@ public class FileRequest implements HttpRequest {
 
     private void guessResourceMimeType(String resource) {
         String mimeType = new Tika().detect(resource);
-        if (mimeType != null) {
-            generalRequest.setContentType(ContentType.create(mimeType));
-        } else {
-            LOG.warning(format("Could not determine %s MIME type. Use setContentType() to change MIME type.", resource));
+
+        if (mimeType.equals("application/octet-stream")) {
+            LOG.warning("Bastion might not have been able to determine the MIME type and is using" +
+                    " [application/octet-stream] for this request. Use setContentType() to change the MIME type.");
         }
+
+        generalRequest.setContentType(ContentType.create(mimeType));
     }
 }

--- a/src/test/java/rocks/bastion/core/FileRequestTest.java
+++ b/src/test/java/rocks/bastion/core/FileRequestTest.java
@@ -107,9 +107,9 @@ public class FileRequestTest extends TestWithEmbeddedServer {
     }
 
     @Test
-    public void contentType_unknownFileType_contentTypeShouldBePlainText() throws Exception {
+    public void contentType_unknownFileType_contentTypeShouldBeOctetStream() throws Exception {
         FileRequest request = FileRequest.post("http://localhost:9876/sushi", "classpath:/rocks/bastion/core/request/unknown.unk");
-        assertThat(request.contentType().get().getMimeType()).describedAs("Request content-type").isEqualTo("text/plain");
+        assertThat(request.contentType().get().getMimeType()).describedAs("Request content-type").isEqualTo("application/octet-stream");
     }
 
     @Test


### PR DESCRIPTION
Related issues: https://github.com/bastion-dev/Bastion/issues/63 https://github.com/bastion-dev/Bastion/issues/77 

Files.probeContentType() was inconsistent across different Operating systems. Apache Tika seems to  be more consistent and does not  have the issue of failing for `classpath:` resources on Windows.

I also changed the default return type for unknown file types to `application/octet-stream`. This seems to be what Apache Tika recommends as a default MIME type and it seems fair. If you want `plain/text`, send a .txt file, otherwise interpret it as a binary stream.