### PR TITLE
Deprecating setGlobalRequestTimeout()

### DIFF
--- a/src/main/java/rocks/bastion/Bastion.java
+++ b/src/main/java/rocks/bastion/Bastion.java
@@ -129,7 +129,7 @@ import static java.util.Objects.requireNonNull;
  * you to add global {@link GlobalRequestAttributes#addQueryParam(String, String) query parameters},
  * {@link GlobalRequestAttributes#addHeader(String, String) headers} and
  * {@link GlobalRequestAttributes#addRouteParam(String, String) route parameters} to all requests you make using Bastion. You can also
- * {@link GlobalRequestAttributes#setGlobalRequestTimeout(long) configure the timeout} which applies to requests.
+ * {@link GlobalRequestAttributes#timeout(long)}  configure the timeout} which applies to requests.
  * </p>
  * <h1>Groovy Tests</h1>
  * <p>

--- a/src/main/java/rocks/bastion/core/configuration/GlobalRequestAttributes.java
+++ b/src/main/java/rocks/bastion/core/configuration/GlobalRequestAttributes.java
@@ -110,7 +110,9 @@ public class GlobalRequestAttributes {
      * Sets the timeout (in milliseconds) for all Bastion requests. A value of 0 indicates no timeout.
      *
      * @see HttpRequest#timeout()
+     * @deprecated use {@link #timeout(long)} instead
      */
+    @Deprecated
     public GlobalRequestAttributes setGlobalRequestTimeout(long globalRequestTimeout) {
         if (globalRequestTimeout < 0) {
             throw new IllegalArgumentException("globalRequestTimeout should be equal to or greater than 0, with 0 indicating no timeout.");


### PR DESCRIPTION
`#setGlobalRequestTimeout()` and `#timeout()` perform the exact same function and contain duplicated code. This PR deprecates one in favour of the other so that it can eventually be removed.